### PR TITLE
fix: invalid host header issue on codesandbox

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -2,7 +2,7 @@
 
 We are more than happy to accept external contributions to the project
 in the form of feedback, bug reports and even better - pull requests :)
-All our CodeSandBox-Samples are [synced-templates](https://codesandbox.io/docs/learn/sandboxes/synced-templates) with our GitHub-repo: they will update automatically, once our repositories main branch got updated.
+All our CodeSandBox-Samples are [synced-templates](https://codesandbox.io/docs/learn/sandboxes/synced-templates) with our GitHub-repo: they will update automatically, once our repositories master branch got updated.
 
 ## How to contribute
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -2,6 +2,7 @@
 
 We are more than happy to accept external contributions to the project
 in the form of feedback, bug reports and even better - pull requests :)
+All our CodeSandBox-Samples are [synced-templates](https://codesandbox.io/docs/learn/sandboxes/synced-templates) with our GitHub-repo: they will update automatically, once our repositories main branch got updated.
 
 ## How to contribute
 

--- a/examples/find-components/.codesandbox/tasks.json
+++ b/examples/find-components/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/find-components/.codesandbox/tasks.json
+++ b/examples/find-components/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/find-components/webpack.config.js
+++ b/examples/find-components/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.js',
   plugins: [

--- a/examples/five-star/.codesandbox/tasks.json
+++ b/examples/five-star/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/five-star/.codesandbox/tasks.json
+++ b/examples/five-star/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/five-star/webpack.config.js
+++ b/examples/five-star/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.js',
   module: {

--- a/examples/get-component-by-dom-node/.codesandbox/tasks.json
+++ b/examples/get-component-by-dom-node/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/get-component-by-dom-node/.codesandbox/tasks.json
+++ b/examples/get-component-by-dom-node/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/get-component-by-dom-node/webpack.config.js
+++ b/examples/get-component-by-dom-node/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.js',
   plugins: [

--- a/examples/gondel-react/.codesandbox/tasks.json
+++ b/examples/gondel-react/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/gondel-react/.codesandbox/tasks.json
+++ b/examples/gondel-react/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/gondel-react/webpack.config.js
+++ b/examples/gondel-react/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.ts',
   module: {

--- a/examples/hello-world/.codesandbox/tasks.json
+++ b/examples/hello-world/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/hello-world/.codesandbox/tasks.json
+++ b/examples/hello-world/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/hello-world/webpack.config.js
+++ b/examples/hello-world/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.js',
   plugins: [

--- a/examples/lazy-load/.codesandbox/tasks.json
+++ b/examples/lazy-load/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/lazy-load/.codesandbox/tasks.json
+++ b/examples/lazy-load/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/lazy-load/webpack.config.js
+++ b/examples/lazy-load/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.js',
   plugins: [

--- a/examples/plugin-data/.codesandbox/tasks.json
+++ b/examples/plugin-data/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/plugin-data/.codesandbox/tasks.json
+++ b/examples/plugin-data/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/plugin-data/webpack.config.js
+++ b/examples/plugin-data/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.ts',
   plugins: [

--- a/examples/plugin-media-query/.codesandbox/tasks.json
+++ b/examples/plugin-media-query/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/plugin-media-query/.codesandbox/tasks.json
+++ b/examples/plugin-media-query/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/plugin-media-query/webpack.config.js
+++ b/examples/plugin-media-query/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.js',
   plugins: [

--- a/examples/plugin-resize/.codesandbox/tasks.json
+++ b/examples/plugin-resize/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/plugin-resize/.codesandbox/tasks.json
+++ b/examples/plugin-resize/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/plugin-resize/webpack.config.js
+++ b/examples/plugin-resize/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.js',
   plugins: [

--- a/examples/react-gondel/.codesandbox/tasks.json
+++ b/examples/react-gondel/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/react-gondel/.codesandbox/tasks.json
+++ b/examples/react-gondel/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/react-gondel/webpack.config.js
+++ b/examples/react-gondel/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.js',
   plugins: [

--- a/examples/trigger-public-event/.codesandbox/tasks.json
+++ b/examples/trigger-public-event/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/trigger-public-event/.codesandbox/tasks.json
+++ b/examples/trigger-public-event/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/trigger-public-event/webpack.config.js
+++ b/examples/trigger-public-event/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.js',
   plugins: [

--- a/examples/typescript/.codesandbox/tasks.json
+++ b/examples/typescript/.codesandbox/tasks.json
@@ -1,20 +1,16 @@
 {
-	// These tasks will run in order when initializing your CodeSandbox project.
 	"setupTasks": [
 		{
 			"name": "Install Dependencies",
 			"command": "yarn install"
 		}
 	],
-
-	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
 	"tasks": {
 		"start": {
 			"name": "start",
 			"command": "yarn start",
 			"runAtStart": true,
 			"preview": {
-				// Set 8080 as primary port for task start
 				"port": 8080
 			}
 		}

--- a/examples/typescript/.codesandbox/tasks.json
+++ b/examples/typescript/.codesandbox/tasks.json
@@ -1,0 +1,22 @@
+{
+	// These tasks will run in order when initializing your CodeSandbox project.
+	"setupTasks": [
+		{
+			"name": "Install Dependencies",
+			"command": "yarn install"
+		}
+	],
+
+	// These tasks can be run from CodeSandbox. Running one will open a log in the app.
+	"tasks": {
+		"start": {
+			"name": "start",
+			"command": "yarn start",
+			"runAtStart": true,
+			"preview": {
+				// Set 8080 as primary port for task start
+				"port": 8080
+			}
+		}
+	}
+}

--- a/examples/typescript/webpack.config.js
+++ b/examples/typescript/webpack.config.js
@@ -9,6 +9,9 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm === 'md4' ? 's
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
+  devServer: {
+		allowedHosts: ['.codesandbox.io', '.csb.app'],
+	},
   context: __dirname,
   entry: './src/index.ts',
   plugins: [


### PR DESCRIPTION
solves Issue #94 (The examples no longer work in CodeSandbox environments.)

We need to add the allowedhosts-flag to devServer-settings for webpack.config:

devServer-config to solve "Invalid Host header Issue" on CodeSandBox:

https://github.com/codesandbox/codesandbox-client/issues/3392 and

https://stackoverflow.com/a/43647767 and
  https://codesandbox.io/docs/learn/repositories/task#configuring-task-ports

https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#firewall

https://webpack.js.org/configuration/dev-server/#devserverallowedhosts

firewall: false, // failed while testing

disableHostCheck: true, // failed while testing

allowedHosts: This flag finally solved it

<!--
Thanks for taking the time to submit a pull request
-->

## Purpose of this pull request? 

<!-- Choose the right options and remove others -->

* Documentation update
* Bug fix
* Enhancement
* Other... Please describe

## What changes did you make?

<!-- Give an overview -->

## Does this pull request introduce a breaking change?

<!-- If this pull request contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->
